### PR TITLE
[WIP] Convert scalaz to cats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,11 @@ target
 
 .idea
 .idea_modules
+.vscode/settings.json
 .cache
 .classpath
 .metadata
 .bloop
 .metals
-
+project/metals.sbt
+project/project/

--- a/core/jvm/src/main/scala/japgolly/clearconfig/internals/SourceJvm.scala
+++ b/core/jvm/src/main/scala/japgolly/clearconfig/internals/SourceJvm.scala
@@ -1,8 +1,8 @@
 package japgolly.clearconfig.internals
 
 import java.io.{ByteArrayInputStream, File, FileInputStream}
-import scalaz.{-\/, Applicative, Monad, \/, \/-}
-import scalaz.syntax.monad._
+import cats._
+import cats.implicits._
 
 object SourceNameJvm extends SourceNameObjectJvm
 trait SourceNameObjectJvm extends SourceNameObject {
@@ -18,7 +18,7 @@ trait SourceObjectJvm extends SourceObject {
     environment(true)
 
   def environment[F[_]](replaceDotsWithUnderscores: Boolean)(implicit F: Applicative[F]): Source[F] = {
-    val s = point(SourceNameJvm.environment.value, StoreJvm.ofMap(sys.env))
+    val s = pure[F](SourceNameJvm.environment.value, StoreJvm.ofMap(sys.env))
     if (replaceDotsWithUnderscores)
       s.mapKeyQueries(k => k :: k.replace('.', '_') :: Nil)
     else
@@ -26,24 +26,24 @@ trait SourceObjectJvm extends SourceObject {
   }
 
   def system[F[_]](implicit F: Applicative[F]): Source[F] =
-    Source[F](SourceNameJvm.system, F.point {
+    Source[F](SourceNameJvm.system, F.pure {
       def cfg() = StoreJvm.ofJavaProps[F](System.getProperties())
-      \/.fromTryCatchNonFatal(cfg()).leftMap(_.getMessage)
+      Either.catchNonFatal(cfg()).leftMap(_.getMessage)
     })
 
   def propFileOnClasspath[F[_]](filename: String, optional: Boolean)(implicit F: Applicative[F]): Source[F] = {
     val f = filename.replaceFirst("^/*", "/")
-    Source[F](SourceNameJvm.classpath(f), F.point {
+    Source[F](SourceNameJvm.classpath(f), F.pure {
       def load() = {
         val i = getClass.getResourceAsStream(f)
         if (i ne null)
-          \/-(StoreJvm.ofJavaPropsFromInputStream[F](i, close = true))
+          Right(StoreJvm.ofJavaPropsFromInputStream[F](i, close = true))
         else if (optional)
-          \/-(StoreJvm.empty[F])
+          Right(StoreJvm.empty[F])
         else
-          -\/("File not found.")
+          Left("File not found.")
       }
-      \/.fromTryCatchNonFatal(load()).leftMap(_.getMessage).flatMap(identity)
+      Either.catchNonFatal(load()).leftMap(_.getMessage).flatMap(identity)
     })
   }
 
@@ -51,19 +51,19 @@ trait SourceObjectJvm extends SourceObject {
     propFile(new File(filename), optional)
 
   def propFile[F[_]](file: File, optional: Boolean)(implicit F: Applicative[F]): Source[F] = {
-    Source[F](SourceName(file.getAbsolutePath), F.point {
+    Source[F](SourceName(file.getAbsolutePath), F.pure {
       def load() =
         if (file.exists()) {
           if (file.canRead) {
             val is = new FileInputStream(file)
-            \/-(StoreJvm.ofJavaPropsFromInputStream[F](is, close = true))
+            Right(StoreJvm.ofJavaPropsFromInputStream[F](is, close = true))
           } else
-            -\/("Unable to read file.")
+            Left("Unable to read file.")
         } else if (optional)
-          \/-(StoreJvm.empty[F])
+          Right(StoreJvm.empty[F])
         else
-          -\/("File not found.")
-      \/.fromTryCatchNonFatal(load()).leftMap(_.getMessage).flatMap(identity)
+          Left("File not found.")
+      Either.catchNonFatal(load()).leftMap(_.getMessage).flatMap(identity)
     })
   }
 
@@ -89,10 +89,10 @@ trait SourceObjectJvm extends SourceObject {
   def expandInlineProperties[F[_]](source: Source[F], key: String)(implicit F: Monad[F]): Source[F] = {
     val k = Key(key)
 
-    val prepare2: F[String \/ Store[F]] =
+    val prepare2: F[Either[String, Store[F]]] =
       source.prepare.flatMap {
 
-        case \/-(store) =>
+        case Right(store) =>
           store.all.flatMap { map =>
             map.get(k) match {
 
@@ -106,17 +106,17 @@ trait SourceObjectJvm extends SourceObject {
                   if (common.nonEmpty) {
                     val hdr = s"The following keys are defined at both the top-level and in ${k.value}: "
                     val keys = common.iterator.map(_.value).toList.sorted
-                    -\/(keys.mkString(hdr, ", ", "."))
+                    Left(keys.mkString(hdr, ", ", "."))
                   } else
-                    \/-(StoreObject[F](F.pure(map ++ map2 - k)))
+                    Right(StoreObject[F](F.pure(map ++ map2 - k)))
                 }
 
               case None =>
-                F.pure(\/-(store))
+                F.pure(Right(store))
             }
           }
 
-        case e@ -\/(_) =>
+        case e@ Left(_) =>
           F.pure(e)
       }
 

--- a/core/jvm/src/main/scala/japgolly/clearconfig/internals/StoreJvm.scala
+++ b/core/jvm/src/main/scala/japgolly/clearconfig/internals/StoreJvm.scala
@@ -3,7 +3,7 @@ package japgolly.clearconfig.internals
 import java.io.InputStream
 import java.util.Properties
 import scala.jdk.CollectionConverters._
-import scalaz.Applicative
+import cats.Applicative
 
 object StoreJvm extends StoreObjectJvm
 trait StoreObjectJvm extends StoreObject {
@@ -16,7 +16,7 @@ trait StoreObjectJvm extends StoreObject {
 
   final def ofJavaProps[F[_]](p: Properties)(implicit F: Applicative[F]): Store[F] = {
     lazy val m = propsToMap(p)
-    apply(F.point(m))
+    apply(F.pure(m))
   }
 
   final def ofJavaPropsFromInputStream[F[_]](is: InputStream, close: Boolean = true)(implicit F: Applicative[F]): Store[F] = {
@@ -28,7 +28,7 @@ trait StoreObjectJvm extends StoreObject {
       } finally
         if (close)
           is.close()
-    apply(F.point(m))
+    apply(F.pure(m))
   }
 
 }

--- a/core/jvm/src/test/scala/japgolly/clearconfig/ConfigJvmTest.scala
+++ b/core/jvm/src/test/scala/japgolly/clearconfig/ConfigJvmTest.scala
@@ -4,9 +4,8 @@ import japgolly.microlibs.testutil.TestUtil._
 import java.io.File
 import java.nio.file.Files
 import java.util.UUID
-import scalaz.{-\/, Equal}
-import scalaz.Scalaz.Id
-import scalaz.syntax.applicative._
+import cats.Id
+import cats.implicits._
 import utest._
 
 object ConfigJvmTest extends TestSuite {
@@ -23,17 +22,17 @@ object ConfigJvmTest extends TestSuite {
       "notFoundMandatory" - {
         val src = ConfigSource.propFileOnClasspath[Id]("what.props", optional = false)
         val r = ConfigDef.get[String]("x").run(src)
-        assertEq(r, ConfigResult.PreparationFailure(src.name, "File not found."))(Equal.equalA, implicitly)
+        assertEq(r, ConfigResult.PreparationFailure(src.name, "File not found."))(Eq.equalA, implicitly)
       }
 
       "notFoundOptional" - {
         val r = ConfigDef.get[String]("x").run(ConfigSource.propFileOnClasspath[Id]("what.props", optional = true))
-        assertEq(r, ConfigResult.Success(None))(Equal.equalA, implicitly)
+        assertEq(r, ConfigResult.Success(None))(Eq.equalA, implicitly)
       }
 
       "found" - {
         val r = ConfigDef.need[String]("from.file.2").run(ConfigSource.propFileOnClasspath[Id]("blah.props", optional = false))
-        assertEq(r, ConfigResult.Success("really good"))(Equal.equalA, implicitly)
+        assertEq(r, ConfigResult.Success("really good"))(Eq.equalA, implicitly)
       }
 
     }
@@ -47,19 +46,19 @@ object ConfigJvmTest extends TestSuite {
         Files.write(tmpFile.toPath, content)
         val src = ConfigSource.propFile[Id](tmpFile.getAbsolutePath, optional = false)
         val r = ConfigDef.get[Int]("a").run(src)
-        assertEq(r, ConfigResult.Success(Option(172)))(Equal.equalA, implicitly)
+        assertEq(r, ConfigResult.Success(Option(172)))(Eq.equalA, implicitly)
       }
 
       "notFoundMandatory" - {
         val src = ConfigSource.propFile[Id](tmpFile.getAbsolutePath, optional = false)
         val r = ConfigDef.get[String]("x").run(src)
-        assertEq(r, ConfigResult.PreparationFailure(src.name, "File not found."))(Equal.equalA, implicitly)
+        assertEq(r, ConfigResult.PreparationFailure(src.name, "File not found."))(Eq.equalA, implicitly)
       }
 
       "notFoundOptional" - {
         val src = ConfigSource.propFile[Id](tmpFile.getAbsolutePath, optional = true)
         val r = ConfigDef.get[String]("x").run(src)
-        assertEq(r, ConfigResult.Success(None))(Equal.equalA, implicitly)
+        assertEq(r, ConfigResult.Success(None))(Eq.equalA, implicitly)
       }
 
     }
@@ -103,8 +102,8 @@ object ConfigJvmTest extends TestSuite {
 
         val cfgDef = ConfigDef.need[String]("x.1")
 
-        val result = cfgDef.run(src).toDisjunction
-        assert(result == -\/("Error preparing source [SourceName(a)]: The following keys are defined at both the top-level and in INLINE: x.1."))
+        val result = cfgDef.run(src).toEither
+        assert(result == Left("Error preparing source [SourceName(a)]: The following keys are defined at both the top-level and in INLINE: x.1."))
       }
     }
 

--- a/core/shared/src/main/scala/japgolly/clearconfig/internals/FailableFunctor.scala
+++ b/core/shared/src/main/scala/japgolly/clearconfig/internals/FailableFunctor.scala
@@ -1,24 +1,24 @@
 package japgolly.clearconfig.internals
 
-import scalaz.{-\/, \/, \/-}
+import cats.implicits._
 
 trait FailableFunctor[F[_], A] {
-  def mapAttempt[B](f: A => String \/ B): F[B]
+  def mapAttempt[B](f: A => Either[String, B]): F[B]
 
   def map[B](f: A => B): F[B] =
-    mapAttempt(a => \/-(f(a)))
+    mapAttempt(a => Right(f(a)))
 
   def test(errorMsg: A => Option[String]): F[A] =
-    mapAttempt(a => errorMsg(a).fold[String \/ A](\/-(a))(-\/.apply))
+    mapAttempt(a => errorMsg(a).fold[Either[String, A]](Right(a))(Left(_)))
 
   def ensure(test: A => Boolean, errorMsg: => String): F[A] =
     this.test(a => if (test(a)) None else Some(errorMsg))
 
   def mapCatch[B](f: A => B, e: Throwable => String = _.toString): F[B] =
-    mapAttempt(a => \/.fromTryCatchNonFatal(f(a)).leftMap(e))
+    mapAttempt(a => Either.catchNonFatal(f(a)).leftMap(e))
 
   def mapOption[B](f: A => Option[B], errorMsg: => String = "Not a recognised value."): F[B] =
-    mapAttempt(f(_).fold[String \/ B](-\/(errorMsg))(\/-.apply))
+    mapAttempt(f(_).toRight(errorMsg))
 
   final def ensure_>=(rhs: A)(implicit o: Ordering[A]): F[A] =
     ensure(o.gteq(_, rhs), s"Must be ≥ $rhs.")

--- a/core/shared/src/main/scala/japgolly/clearconfig/internals/Sources.scala
+++ b/core/shared/src/main/scala/japgolly/clearconfig/internals/Sources.scala
@@ -1,6 +1,6 @@
 package japgolly.clearconfig.internals
 
-import scalaz.{Applicative, ~>}
+import cats.{Applicative, ~>}
 
 final case class Sources[F[_]](highToLowPri: Vector[Source[F]]) extends AnyVal {
   override def toString: String =

--- a/core/shared/src/main/scala/japgolly/clearconfig/internals/Store.scala
+++ b/core/shared/src/main/scala/japgolly/clearconfig/internals/Store.scala
@@ -1,8 +1,7 @@
 package japgolly.clearconfig.internals
 
-import scalaz.{Applicative, ~>}
-import scalaz.std.list._
-import scalaz.syntax.traverse._
+import cats.{Applicative, ~>}
+import cats.implicits._
 import japgolly.microlibs.stdlib_ext.StdlibExt._
 
 final class Store[F[_]](val all : F[Map[Key, String]],
@@ -77,7 +76,7 @@ trait StoreObject {
 
   final def ofMap[F[_]](m: => Map[String, String])(implicit F: Applicative[F]): Store[F] = {
     lazy val m2 = m.mapKeysNow(Key)
-    apply(F.point(m2))
+    apply(F.pure(m2))
   }
 }
 

--- a/core/shared/src/test/scala/japgolly/clearconfig/ConfigReportTest.scala
+++ b/core/shared/src/test/scala/japgolly/clearconfig/ConfigReportTest.scala
@@ -2,9 +2,8 @@ package japgolly.clearconfig
 
 import japgolly.microlibs.stdlib_ext.StdlibExt._
 import japgolly.microlibs.testutil.TestUtil._
-import scalaz.Scalaz.Id
-import scalaz.std.string._
-import scalaz.syntax.applicative._
+import cats.Id
+import cats.implicits._
 import utest._
 import Helpers._
 

--- a/core/shared/src/test/scala/japgolly/clearconfig/ConfigValueParserTest.scala
+++ b/core/shared/src/test/scala/japgolly/clearconfig/ConfigValueParserTest.scala
@@ -2,8 +2,6 @@ package japgolly.clearconfig
 
 import japgolly.microlibs.testutil.TestUtil._
 import java.net.URL
-import scalaz.std.AllInstances._
-import scalaz.{-\/, Equal, \/-}
 import utest._
 import Helpers._
 
@@ -12,13 +10,13 @@ object ConfigValueParserTest extends TestSuite {
   val k = Key("k")
   val pp = implicitly[ConfigValuePreprocessor]
 
-  def testOk[A: ConfigValueParser: Equal](origValue: String, expect: A): Unit =
-    assertEq(ConfigValueParser[A].parse(pp.run(origValue)), \/-(expect))
+  def testOk[A: ConfigValueParser: Eq](origValue: String, expect: A): Unit =
+    assertEq(ConfigValueParser[A].parse(pp.run(origValue)), Right(expect))
 
-  def testBad[A: ConfigValueParser : Equal](origValue: String, errorFrag: String = ""): Unit =
+  def testBad[A: ConfigValueParser : Eq](origValue: String, errorFrag: String = ""): Unit =
     ConfigValueParser[A].parse(pp.run(origValue)) match {
-      case -\/(e) => assertContainsCI(e, errorFrag)
-      case \/-(a) => fail(s"Error expected containing '$errorFrag', instead it passed with $a.")
+      case Left(e) => assertContainsCI(e, errorFrag)
+      case Right(a) => fail(s"Error expected containing '$errorFrag', instead it passed with $a.")
     }
 
   override def tests = Tests {
@@ -80,7 +78,7 @@ object ConfigValueParserTest extends TestSuite {
         sealed trait X
         case object A extends X
         case object B extends X
-        implicit val eq = Equal.equalA[X]
+        implicit val eq = Eq.equalA[X]
         implicit val v = ConfigValueParser.oneOf[X]("A" -> A, "B" -> B).preprocessValue(_.toUpperCase)
         testOk[X]("a", A)
         testOk[X]("A", A)

--- a/core/shared/src/test/scala/japgolly/clearconfig/Helpers.scala
+++ b/core/shared/src/test/scala/japgolly/clearconfig/Helpers.scala
@@ -1,7 +1,7 @@
 package japgolly.clearconfig
 
 import japgolly.microlibs.testutil.TestUtil._
-import scalaz.Scalaz.Id
+import cats.Id
 
 object Helpers extends internals.Exports {
   type Key = internals.Key
@@ -18,8 +18,8 @@ object Helpers extends internals.Exports {
   override type ConfigSourceNameObject = internals.SourceNameObject
   override val ConfigSourceName = internals.SourceName
 
-  implicit def equalResultX[A] = scalaz.Equal.equalA[ConfigResult[A]]
-  implicit def equalURL = scalaz.Equal.equalA[java.net.URL]
+  implicit def equalResultX[A] = cats.Eq.equalA[ConfigResult[A]]
+  implicit def equalURL = cats.Eq.equalA[java.net.URL]
 
   val src0 = ConfigSource.manual[Id]("S0")()
   val src1 = ConfigSource.manual[Id]("S1")("in" -> "100", "i" -> "3", "s" -> "hey", "dur3m" -> "3 min")
@@ -28,7 +28,7 @@ object Helpers extends internals.Exports {
   val srcs: ConfigSources[Id] = src1 > src2
   val srcNames = srcs.highToLowPri.map(_.name)
 
-  val srcE = ConfigSource.point[Id]("SE",
+  val srcE = ConfigSource.pure[Id]("SE",
     ConfigStore[Id](Map.empty[Key, String], (_: Key) => Lookup.Error("This source is fake!", None)))
 
   implicit class ResultXExt[A](private val self: ConfigResult[A]) extends AnyVal {

--- a/core/shared/src/test/scala/japgolly/clearconfig/SourceTest.scala
+++ b/core/shared/src/test/scala/japgolly/clearconfig/SourceTest.scala
@@ -1,6 +1,6 @@
 package japgolly.clearconfig
 
-import scalaz.Scalaz.Id
+import cats.Id
 import utest._
 import Helpers._
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,14 +16,14 @@ object ClearConfig {
     Lib.publicationSettings(ghProject)
 
   object Ver {
+    val Cats            = "2.1.1"
     val JavaTimeScalaJs = "0.2.6"
     val KindProjector   = "0.10.3"
     val Microlibs       = "2.0"
     val MTest           = "0.7.1"
-    val Scala212        = "2.12.10"
+    val Scala212        = "2.12.12"
     val Scala213        = "2.13.1"
     val ScalaCollCompat = "2.1.3"
-    val Scalaz          = "7.2.30"
   }
 
   def scalacFlags =
@@ -49,6 +49,7 @@ object ClearConfig {
       scalaVersion                  := Ver.Scala213,
       crossScalaVersions            := Seq(Ver.Scala212, Ver.Scala213),
       scalacOptions                ++= scalacFlags,
+      scalacOptions                ++= {if (scalaVersion.value.startsWith("2.12")) Seq("-Ypartial-unification") else Seq.empty},
       scalacOptions in Test        --= Seq("-Ywarn-dead-code", "-Ywarn-unused"),
       shellPrompt in ThisBuild      := ((s: State) => Project.extract(s).currentRef.project + "> "),
       updateOptions                 := updateOptions.value.withCachedResolution(true),
@@ -76,8 +77,8 @@ object ClearConfig {
     .configureCross(commonSettings, publicationSettings, utestSettings)
     .settings(
       libraryDependencies ++= Seq(
+        "org.typelevel"                 %%% "cats-core"               % Ver.Cats,
         "org.scala-lang.modules"        %%% "scala-collection-compat" % Ver.ScalaCollCompat,
-        "org.scalaz"                    %%% "scalaz-core"             % Ver.Scalaz,
         "com.github.japgolly.microlibs" %%% "stdlib-ext"              % Ver.Microlibs,
         "com.github.japgolly.microlibs" %%% "test-util"               % Ver.Microlibs % Test,
         "com.github.japgolly.microlibs" %%% "utils"                   % Ver.Microlibs))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.13


### PR DESCRIPTION
Pretty mechanical replacement, without many api changes (though it does have some; this is a breaking change obviously).

I may need to add a test for the `StackSafeMonad` instance; I did that to make it compile but I haven't checked yet that it's valid

Updating to latest cats also means the scalajs build needs to be updated, dunno how much effort that will be. Microlibs also needs to be updated